### PR TITLE
fix: NodeNext moduleResolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
 	"types": "dist/index.d.ts",
 	"exports": {
 		"import": "./dist/index.mjs",
-		"require": "./dist/index.js"
+		"require": "./dist/index.js",
+		"types": "./dist/index.d.ts"
 	},
 	"sideEffects": false,
 	"homepage": "https://skyra-project.github.io/gifenc",


### PR DESCRIPTION
Fixes the following error when using `"moduleResolution": "NodeNext"` in tsconfig

![image](https://user-images.githubusercontent.com/42935195/198363510-4a20e440-6c6a-42ab-933b-163c07a2efe4.png)
